### PR TITLE
[Fix] Link to GitHub repository in Documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,7 +101,7 @@ remove_from_toctrees = ["_autosummary/*"]
 html_theme = 'pydata_sphinx_theme'
 
 html_theme_options = {
-    "github_url": "https://osipi.github.io/pypi",
+    "github_url": "https://github.com/OSIPI/pypi",
     "collapse_navigation": True,
     }
 


### PR DESCRIPTION
## Description 
The GitHub button in the navigation bar of pypi documentation points to  [documentation of pypi ](https://osipi.github.io/pypi/)  i.e. Same Page .

## Expected Behaviour 
It should either navigate to [GitHub page of OSIPI ](https://github.com/OSIPI) or the [  GitHub repository of pypi](https://github.com/OSIPI/pypi)

## Screen Recording

https://github.com/OSIPI/pypi/assets/100958893/db5f851d-e2f5-4425-abfb-1a1f27affa0e


