### PR TITLE
[Feat] Added Edit on GitHub BUtton

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,15 @@ html_theme = 'pydata_sphinx_theme'
 html_theme_options = {
     "github_url": "https://osipi.github.io/pypi",
     "collapse_navigation": True,
-    }
+    "use_edit_page_button": True,
+}
+html_context = {
+    "github_url": "https://github.com",
+    "github_user": "OSIPI", 
+    "github_repo": "pypi", 
+    "github_version":"dev",
+    "doc_path": "docs/source",
+}
 
 # Add any paths that contain custom static files (such as style sheets) here, relative to this directory. They are copied after the builtin static files, so a file named "default.css" will overwrite the builtin "default.css"
 html_static_path = ['_static']


### PR DESCRIPTION
## Description 
Added an edit this page link to each webpage that links to their corresponding source file, allowing users to quickly fork and add/improve content.

## Impact 
This will make it easier for users to suggest improvements directly to the source file, promoting collaboration and faster content improvement.

## Screenshot of changes
### `Edit on GitHub` button
![image](https://github.com/OSIPI/pypi/assets/100958893/7dc3baa3-877d-49f6-be31-22aa84ab22af)

### Clicking the button opens the current page in GitHub. User can change it and send a PR accordingly. 
![image](https://github.com/OSIPI/pypi/assets/100958893/eb81c002-04ad-49b2-95a5-d3bb9f665102)


## NOTE 
Currently, button directs all the PR to the `dev` branch.

I suggest creating a new branch with name `docs` or `docs-improvement` so that we can easily keep track of incoming suggestions. [I'll update the code once the branch is created. ] 