### PR TITLE
Ignore Build related files and Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 /.venv
+build/
+__pycache__/


### PR DESCRIPTION
## Current 
The `build` and `py cache` are tracked by Git, which are not required. 

## Fix
Added them to `.gitignore`