### PR TITLE
[🔨Fix] Removed logging module form requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 scipy
 matplotlib
-logging


### PR DESCRIPTION
# Issue 
The `logging` module is part of the Python Standard Library, which means it comes pre-installed with Python and does not need to be installed separately.
We just need to use import `logging` in python code
### Introduced in PR 
- #18


### Screen shot
![image](https://github.com/OSIPI/pypi/assets/100958893/17ff349b-e061-4c9f-bfd2-f4ca1e4f0a7c)




## Fix 
Removed  logging from `requirements.txt`

